### PR TITLE
Added notebook's name search property

### DIFF
--- a/searching-proposal.org
+++ b/searching-proposal.org
@@ -25,6 +25,7 @@ Following properties are supported:
 
 | =title=    | note's title              |
 | =body=     | note's body               |
+| =b=        | notebook's name           |
 | =s=        | scheduled time            |
 | =d=        | deadline time             |
 | =c=        | closed time               |


### PR DESCRIPTION
The notebook's name property ("b") was missing from the Orgzly Search (PROPOSAL)